### PR TITLE
behavior better separated from tax law params

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include taxcalc/_version.py
 include taxcalc/StageIFactors.csv
 include taxcalc/WEIGHTS.csv
 include taxcalc/params.json
+include taxcalc/behavior.json

--- a/docs/notebooks/Behavioral_example.ipynb
+++ b/docs/notebooks/Behavioral_example.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -46,14 +46,6 @@
       "You loaded data for 2009.\n",
       "Your data have been extrapolated to 2013.\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/Matt.Jensen/anaconda/lib/python2.7/site-packages/pandas/io/parsers.py:1170: DtypeWarning: Columns (204,205) have mixed types. Specify dtype option on import or set low_memory=False.\n",
-      "  data = self._reader.read(nrows)\n"
-     ]
     }
    ],
    "source": [
@@ -63,10 +55,11 @@
     "# Create a Parameters object for Plan X and Plan Y\n",
     "params_x = Parameters()\n",
     "params_y = Parameters()\n",
+    "behavior_y = Behavior()\n",
     "\n",
     "# Create two Calculators\n",
     "calcX = Calculator(params_x, records_x)\n",
-    "calcY = Calculator(params_y, records_y)\n"
+    "calcY = Calculator(params_y, records_y, behavior=behavior_y)\n"
    ]
   },
   {
@@ -78,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -110,21 +103,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
     "# Call the behavioral effects calculator and create new Plan Y Calculator obects. \n",
-    "calcY_behavior1 = behavior(calcX, calcY, elast_wrt_atr=0.4, inc_effect=0.15)\n",
-    "calcY_behavior2 = behavior(calcX, calcY, elast_wrt_atr=0.5, inc_effect=0.15)\n",
-    "calcY_behavior3 = behavior(calcX, calcY, elast_wrt_atr=0.4, inc_effect=0)                           "
+    "behavior_y.implement_reform({2013: {'_BE_inc': [0.15], '_BE_sub': [0.4]}})\n",
+    "calcY_behavior1 = behavior(calcX, calcY)\n",
+    "behavior_y.implement_reform({2013: {'_BE_inc': [0.15], '_BE_sub': [0.5]}})\n",
+    "calcY_behavior2 = behavior(calcX, calcY)\n",
+    "behavior_y.implement_reform({2013: {'_BE_inc': [0.0], '_BE_sub': [0.4]}})\n",
+    "calcY_behavior3 = behavior(calcX, calcY)                           "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -150,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 12,
    "metadata": {
     "collapsed": false
    },

--- a/taxcalc/behavior.json
+++ b/taxcalc/behavior.json
@@ -3,7 +3,6 @@
         "long_name": "Income effect",
         "description": "Behavior effect",
         "row_label": ["2013"],
-        "cpi_inflated": false,
         "col_label": "",
         "value": [0.0]
     },
@@ -12,7 +11,6 @@
         "long_name": "Substitution effect",
         "description": "Behavior effect",
         "row_label": ["2013"],
-        "cpi_inflated": false,
         "col_label": "",
         "value": [0.0]
     },
@@ -21,7 +19,6 @@
         "long_name": "Persistent",
         "description": "Behavior effect",
         "row_label": ["2013"],
-        "cpi_inflated": false,
         "col_label": "",
         "value": [0.0]
     }

--- a/taxcalc/behavior.json
+++ b/taxcalc/behavior.json
@@ -1,0 +1,28 @@
+{   "_BE_inc":{
+        "start_year": 2013,
+        "long_name": "Income effect",
+        "description": "Behavior effect",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0]
+    },
+    "_BE_sub":{
+        "start_year": 2013,
+        "long_name": "Substitution effect",
+        "description": "Behavior effect",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0]
+    },
+    "_BE_CG_per":{
+        "start_year": 2013,
+        "long_name": "Persistent",
+        "description": "Behavior effect",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value": [0.0]
+    }
+}

--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -157,6 +157,9 @@ class Behavior(object):
 
     def implement_reform(self, reform):
         self.set_default_vals()
+        if self.current_year != self.start_year:
+            self.set_year(self.start_year)
+        
         for year in reform:
             if year != self.start_year:
                 self.set_year(year)
@@ -173,7 +176,7 @@ class Behavior(object):
                                     num_years=num_years_to_expand)
                 
                 cval[(self.current_year - self.start_year):] = nval
-        self.set_year(self._current_year)
+        self.set_year(self.start_year)
 
     def set_year(self, year):
         """

--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -1,6 +1,9 @@
-import numpy as np
 import copy
-
+import json
+import os
+import numpy as np
+from .parameters import Parameters
+from .utils import expand_array
 
 def update_income(behavioral_effect, calc_y):
     delta_inc = np.where(calc_y.records.c00100 > 0, behavioral_effect, 0)
@@ -58,10 +61,10 @@ def behavior(calc_x, calc_y, update_income=update_income):
     pct_diff_atr = ((1 - mtrY) - (1 - mtrX)) / (1 - mtrX)
 
     # Calculate the magnitude of the substitution and income effects.
-    substitution_effect = (calc_y.params.BE_sub * pct_diff_atr *
+    substitution_effect = (calc_y.behavior.BE_sub * pct_diff_atr *
                            (calc_x.records.c04800))
 
-    income_effect = calc_y.params.BE_inc * (calc_y.records._ospctax -
+    income_effect = calc_y.behavior.BE_inc * (calc_y.records._ospctax -
                                             calc_x.records._ospctax)
     calc_y_behavior = copy.deepcopy(calc_y)
 
@@ -71,3 +74,139 @@ def behavior(calc_x, calc_y, update_income=update_income):
                                     calc_y_behavior)
 
     return calc_y_behavior
+
+class Behavior(object):
+
+    JSON_START_YEAR = Parameters.JSON_START_YEAR
+    BEHAVIOR_FILENAME = 'behavior.json'
+    DEFAULT_NUM_YEARS = Parameters.DEFAULT_NUM_YEARS
+
+    def __init__(self, behavior_dict=None,
+                 start_year=JSON_START_YEAR,
+                 num_years=DEFAULT_NUM_YEARS,
+                 inflation_rates=None):
+        if behavior_dict:
+            if not isinstance(behavior_dict, dict):
+                raise ValueError('behavior_dict is not a dictionary')
+            self._vals = behavior_dict
+        else:  # if None, read current-law parameters
+            self._vals = self._behavior_dict_from_json_file()
+
+        if num_years < 1:
+            raise ValueError('num_years < 1')
+
+        self._current_year = start_year
+        self._start_year = start_year
+        self._num_years = num_years
+        self._end_year = start_year + num_years - 1
+        self.set_default_vals()
+
+    def set_default_vals(self):
+        # extend current-law parameter values into future with _inflation_rates
+        for name, data in self._vals.items():
+            values = data['value']
+            setattr(self, name,
+                    expand_array(values, inflate=False,
+                                 inflation_rates=None,
+                                 num_years=self._num_years))
+        self.set_year(self._start_year)
+
+    @property 
+    def num_years(self):
+        return self._num_years
+
+    @property
+    def current_year(self):
+        return self._current_year
+    
+    @property
+    def end_year(self):
+        return self._end_year
+    
+    @property
+    def start_year(self):
+        return self._start_year
+
+    @staticmethod
+    def _behavior_dict_from_json_file():
+        """
+        Read params.json file and return complete params dictionary.
+
+        Parameters
+        ----------
+        nothing: void
+
+        Returns
+        -------
+        params: dictionary
+            containing complete contents of params.json file.
+        """
+        behavior_path = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                                   Behavior.BEHAVIOR_FILENAME)
+        if os.path.exists(behavior_path):
+            with open(behavior_path) as pfile:
+                behavior = json.load(pfile)
+        else:
+            from pkg_resources import resource_stream, Requirement
+            path_in_egg = os.path.join('taxcalc', Behavior.BEHAVIOR_FILENAME)
+            buf = resource_stream(Requirement.parse('taxcalc'), path_in_egg)
+            as_bytes = buf.read()
+            as_string = as_bytes.decode("utf-8")
+            behavior = json.loads(as_string)
+        return behavior
+
+    def implement_reform(self, reform):
+        self.set_default_vals()
+        for year in reform:
+            if year != self.start_year:
+                self.set_year(year)
+            num_years_to_expand = (self.start_year + self.num_years) - year
+            for name, values in reform[year].items():
+                # determine inflation indexing status of parameter with name
+                cval = getattr(self, name, None)
+                if cval is None:
+                    # it is a tax law parameter not behavior
+                    continue
+                nval = expand_array(values,
+                                    inflate=False,
+                                    inflation_rates=None,
+                                    num_years=num_years_to_expand)
+                
+                cval[(self.current_year - self.start_year):] = nval
+        self.set_year(self._current_year)
+
+    def set_year(self, year):
+        """
+        Set behavior parameters to values for specified calendar year.
+
+        Parameters
+        ----------
+        year: int
+            calendar year for which to current_year and parameter values
+
+        Raises
+        ------
+        ValueError:
+            if year is not in [start_year, end_year] range.
+
+        Returns
+        -------
+        nothing: void
+
+        Notes
+        -----
+        To increment the current year, use the following statement::
+
+            behavior.set_year(behavior.current_year + 1)
+
+        where behavior is a policy Behavior object.
+        """
+        if year < self.start_year or year > self.end_year:
+            msg = 'year passed to set_year() must be in [{},{}] range.'
+            raise ValueError(msg.format(self.start_year, self.end_year))
+        self._current_year = year
+        year_zero_indexed = year - self._start_year
+        for name in self._vals:
+            arr = getattr(self, name)
+            setattr(self, name[1:], arr[year_zero_indexed])
+

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -1,12 +1,13 @@
+import math
+import copy
+import numpy as np
 import pandas as pd
 from pandas import DataFrame
-import math
-import numpy as np
 from .utils import *
 from .functions import *
 from .parameters import Parameters
 from .records import Records
-import copy
+from .behavior import Behavior
 
 all_cols = set()
 
@@ -24,13 +25,17 @@ def add_df(alldfs, df):
 
 class Calculator(object):
 
-    def __init__(self, params=None, records=None, sync_years=True, **kwargs):
+    def __init__(self, params=None, records=None, sync_years=True, behavior=None, **kwargs):
 
         if isinstance(params, Parameters):
             self._params = params
         else:
             msg = 'Must supply tax parameters as a Parameters object'
             raise ValueError(msg)
+        if isinstance(behavior, Behavior):
+            self.behavior = behavior
+        else:
+            self.behavior = Behavior(start_year=params.start_year)
 
         if isinstance(records, Records):
             self._records = records
@@ -132,6 +137,7 @@ class Calculator(object):
     def increment_year(self):
         self.records.increment_year()
         self.params.set_year(self.params.current_year + 1)
+        self.behavior.set_year(self.behavior.current_year + 1)
 
     @property
     def current_year(self):

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -137,7 +137,7 @@ class Calculator(object):
     def increment_year(self):
         self.records.increment_year()
         self.params.set_year(self.params.current_year + 1)
-        self.behavior.set_year(self.behavior.current_year + 1)
+        self.behavior.set_year(self.params.current_year)
 
     @property
     def current_year(self):

--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -477,11 +477,14 @@ class Parameters(object):
                 default_cpi = False
             cpi_inflated = year_mods[year].get(name + '_cpi', default_cpi)
             # set post-reform values of parameter with name
+            cval = getattr(self, name, None)
+            if cval is None:
+                # it is a behavior parameter instead
+                continue
             nval = expand_array(values,
                                 inflate=cpi_inflated,
                                 inflation_rates=inf_rates,
                                 num_years=num_years_to_expand)
-            cval = getattr(self, name)
             cval[(self.current_year - self.start_year):] = nval
         self.set_year(self._current_year)
 

--- a/taxcalc/params.json
+++ b/taxcalc/params.json
@@ -1265,32 +1265,5 @@
         "value": [  [400000, 450000, 225000, 425000, 450000, 225000],
                     [406750, 457600, 228800, 432200, 457600, 228800],
                     [413200, 464850, 223425, 439000, 464850, 223425]]
-    },
-        "_BE_inc":{
-        "start_year": 2013,
-        "long_name": "Income effect",
-        "description": "Behavior effect",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.0]
-    },
-       "_BE_sub":{
-        "start_year": 2013,
-        "long_name": "Substitution effect",
-        "description": "Behavior effect",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.0]
-    },
-       "_BE_CG_per":{
-        "start_year": 2013,
-        "long_name": "Persistent",
-        "description": "Behavior effect",
-        "row_label": ["2013"],
-        "cpi_inflated": false,
-        "col_label": "",
-        "value": [0.0]
     }
 }

--- a/taxcalc/tests/test_behavior.py
+++ b/taxcalc/tests/test_behavior.py
@@ -1,9 +1,10 @@
 import os
 import sys
+import numpy as np
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, "../../"))
 import pandas as pd
-from taxcalc import Parameters, Records, Calculator, behavior
+from taxcalc import Parameters, Records, Calculator, behavior, Behavior
 
 
 WEIGHTS_FILENAME = "../../WEIGHTS_testing.csv"
@@ -23,8 +24,9 @@ def test_make_behavioral_Calculator():
     params_x = Parameters()
     params_y = Parameters()
     # create two Calculators
+    behavior_y = Behavior(start_year=2009)
     calc_x = Calculator(params=params_x, records=records_x)
-    calc_y = Calculator(params=params_y, records=records_y)
+    calc_y = Calculator(params=params_y, records=records_y, behavior=behavior_y)
     # Implement a plan Y reform
     reform = {
         2013: {
@@ -34,6 +36,7 @@ def test_make_behavioral_Calculator():
         }
     }
     params_y.implement_reform(reform)
+    behavior_y.implement_reform(reform)
     # Create behavioral calculators and vary substitution and income effects.
     calc_y_behavior1 = behavior(calc_x, calc_y)
     reform = {
@@ -44,6 +47,7 @@ def test_make_behavioral_Calculator():
         }
     }
     params_y.implement_reform(reform)
+    behavior_y.implement_reform(reform)
     calc_y_behavior2 = behavior(calc_x, calc_y)
     reform = {
         2013: {
@@ -53,7 +57,21 @@ def test_make_behavioral_Calculator():
         }
     }
     params_y.implement_reform(reform)
+    behavior_y.implement_reform(reform)
     calc_y_behavior3 = behavior(calc_x, calc_y)
     assert (calc_y_behavior1.records._ospctax.sum() !=
             calc_y_behavior2.records._ospctax.sum() !=
             calc_y_behavior3.records._ospctax.sum())
+
+def test_implement_reform():
+
+    b = Behavior(start_year=2013)
+    b.implement_reform({2014: {'_BE_sub':[0.5], '_II_rt7': [0.3]}})
+    should_be = np.full((12,), 0.5)
+    should_be[0] = 0.0
+    assert np.allclose(b._BE_sub, should_be, rtol=0.0)
+    assert np.allclose(b._BE_inc, np.zeros((12,)), rtol=0.0)
+    b.set_year(2015)
+    assert b.current_year == 2015
+    assert b.BE_sub == 0.5
+    assert b.BE_inc == 0.0

--- a/taxcalc/tests/test_behavior.py
+++ b/taxcalc/tests/test_behavior.py
@@ -24,7 +24,7 @@ def test_make_behavioral_Calculator():
     params_x = Parameters()
     params_y = Parameters()
     # create two Calculators
-    behavior_y = Behavior(start_year=2009)
+    behavior_y = Behavior()
     calc_x = Calculator(params=params_x, records=records_x)
     calc_y = Calculator(params=params_y, records=records_y, behavior=behavior_y)
     # Implement a plan Y reform


### PR DESCRIPTION
1) moved behavior input parameters from params.json to behavior.json
2) added a Behavior class in behavior.py that has implement_reform, set_year, current_year and other attributes similar to the tax law parameters class Parameters.
3) added a behavior=None argument to Calculator
4) in Calculator made increment_year do the set_year method of self.behavior and self.params
5) updated the behavior test based on new syntax
6) updated the ipython notebook Behavioral_example.ipynb
 